### PR TITLE
docs: Add editor integration section to README

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -14,10 +14,20 @@ from typing import Optional, List, Dict, Any
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent))
 
-import json # Added for SSE
-from starlette.requests import Request # Added for SSE, assuming FastMCP uses Starlette
-from starlette.responses import StreamingResponse # Added for SSE, assuming FastMCP uses Starlette
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Optional, List, Dict, Any
 
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent))
+
+from starlette.requests import Request
+from starlette.responses import StreamingResponse
+
+from mcp.server.fastmcp import FastMCP, Context
 from mcp.server.fastmcp import FastMCP, Context
 
 # Import with absolute paths

--- a/src/main.py
+++ b/src/main.py
@@ -850,13 +850,12 @@ async def sse_event_generator(request: Request):
     except Exception as e:
         logger.error(f"Error in SSE event generator: {e}")
         # Yield an error event if possible, or just log and exit
-        try:
+        # Try to yield error event - if connection is closed, this will fail silently
+        with contextlib.suppress(ConnectionError, RuntimeError):
             yield {
                 "event": "error",
                 "data": json.dumps({"error": str(e)})
             }
-        except: # If yielding fails (e.g. connection already closed)
-            pass
     finally:
         logger.info("SSE event generator finished.")
 

--- a/tests/test_new_endpoints.py
+++ b/tests/test_new_endpoints.py
@@ -3,12 +3,13 @@ Tests for new stdio, HTTP, and SSE endpoints.
 """
 
 import asyncio
-import sys
-import pytest
-import httpx
 import json
+import sys
 from pathlib import Path
-from typing import AsyncGenerator, Any, Dict
+from typing import AsyncGenerator
+
+import httpx
+import pytest
 
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))

--- a/tests/test_new_endpoints.py
+++ b/tests/test_new_endpoints.py
@@ -1,0 +1,214 @@
+"""
+Tests for new stdio, HTTP, and SSE endpoints.
+"""
+
+import asyncio
+import sys
+import pytest
+import httpx
+import json
+from pathlib import Path
+from typing import AsyncGenerator, Any, Dict
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from main import (
+    mcp,  # The FastMCP instance
+    initialize_services,
+    cleanup_services,
+    handle_stdio_input,
+    # stream_events, # This is a tool, but also an HTTP endpoint. How it's called matters.
+    OpenEduMCPError # Assuming this is the correct exception
+)
+# If stream_events is directly callable as a tool for some reason, import it.
+# Otherwise, it will be tested via HTTP.
+
+# Attempt to get the ASGI app from mcp instance for httpx
+# This is speculative. Common names are .app, .asgi_app, .server.app
+ASGI_APP = getattr(mcp, "app", None) or getattr(mcp, "asgi_app", None)
+if hasattr(mcp, "server") and mcp.server:
+    ASGI_APP = ASGI_APP or getattr(mcp.server, "app", None)
+
+
+# MockContext from existing integration tests
+class MockContext:
+    """Mock context for testing MCP tools."""
+    def __init__(self, session_id: str = "test_session"):
+        self.session_id = session_id
+        # Add any other fields that tools might expect from the context
+        self.user = None
+        self.client_ip = "127.0.0.1"
+
+
+@pytest.fixture(scope="module")
+def event_loop():
+    """Create an instance of the default event loop for each test module."""
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()
+
+@pytest.fixture(scope="module")
+async def initialized_services() -> AsyncGenerator[None, None]:
+    """Initialize and cleanup services once per module."""
+    print("Initializing services for test module...")
+    await initialize_services()
+    print("Services initialized.")
+    yield
+    print("Cleaning up services...")
+    await cleanup_services()
+    print("Services cleaned up.")
+
+
+# --- Test Stdio Endpoint ---
+class TestStdioEndpoint:
+    @pytest.mark.asyncio
+    async def test_handle_stdio_basic_processing(self, initialized_services: None):
+        ctx = MockContext()
+        result = await handle_stdio_input(ctx, "hello world")
+        assert result == "Processed: HELLO WORLD"
+
+    @pytest.mark.asyncio
+    async def test_handle_stdio_empty_input(self, initialized_services: None):
+        ctx = MockContext()
+        with pytest.raises(OpenEduMCPError, match="Input string cannot be empty"):
+            await handle_stdio_input(ctx, "")
+
+    @pytest.mark.asyncio
+    async def test_handle_stdio_with_numbers_and_symbols(self, initialized_services: None):
+        ctx = MockContext()
+        result = await handle_stdio_input(ctx, "Test 123!@#")
+        assert result == "Processed: TEST 123!@#"
+
+
+# --- Test HTTP Interaction with Tools ---
+# These tests depend on knowing how FastMCP exposes tools over HTTP.
+# Common patterns: /mcp/<tool_name>, /tools/<tool_name>, or /rpc
+# And the JSON RPC structure.
+# For now, we assume a base_url and that httpx can connect if the server is run separately,
+# OR if ASGI_APP is successfully found.
+
+BASE_URL = "http://127.0.0.1:8000" # Default for Uvicorn if not configured otherwise in FastMCP
+
+class TestHttpViaToolEndpoint:
+    @pytest.mark.asyncio
+    async def test_http_call_stdio_tool_directly(self, initialized_services: None):
+        """
+        This test assumes FastMCP exposes an ASGI app instance (mcp.app)
+        that httpx can use directly. This is preferred over running a live server.
+        """
+        if not ASGI_APP:
+            pytest.skip("ASGI app not found on MCP instance, skipping direct HTTP test.")
+
+        async with httpx.AsyncClient(app=ASGI_APP, base_url="http://testserver") as client:
+            # The URL and request format are assumptions about FastMCP's JSON RPC implementation
+            # Option 1: JSON RPC style
+            response = await client.post(
+                "/mcp", # Assuming a single RPC endpoint
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "handle_stdio_input",
+                    "params": {"input_string": "http test"},
+                    "id": 1,
+                },
+            )
+            # Option 2: Simpler tool call endpoint (if FastMCP uses this)
+            # response = await client.post(
+            #     "/tools/handle_stdio_input",
+            #     json={"params": {"input_string": "http test"}}
+            # )
+
+            assert response.status_code == 200
+            data = response.json()
+
+            # Depending on JSON RPC spec, result might be under "result" or "data"
+            if "result" in data: # Standard JSON RPC
+                assert data["result"] == "Processed: HTTP TEST"
+            elif "data" in data: # Other conventions
+                 assert data["data"] == "Processed: HTTP TEST"
+            else: # Or if it's a direct result not wrapped in JSON RPC success
+                 assert data == "Processed: HTTP TEST"
+
+
+    @pytest.mark.asyncio
+    async def test_http_call_stdio_tool_empty_param_directly(self, initialized_services: None):
+        if not ASGI_APP:
+            pytest.skip("ASGI app not found on MCP instance, skipping direct HTTP test.")
+
+        async with httpx.AsyncClient(app=ASGI_APP, base_url="http://testserver") as client:
+            response = await client.post(
+                "/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "handle_stdio_input",
+                    "params": {"input_string": ""}, # Empty string
+                    "id": 2,
+                },
+            )
+            # Expecting an error, but not a connection error.
+            # The error should be from the tool's validation logic.
+            assert response.status_code == 200 # JSON-RPC usually returns 200 for application errors
+            data = response.json()
+            assert "error" in data
+            assert data["error"]["message"] == "Input string cannot be empty"
+            # Or, if not JSON-RPC, it might be a 4xx/5xx error directly
+            # assert response.status_code == 400 or response.status_code == 500
+
+
+# --- Test SSE Endpoint (/events) ---
+class TestSseEndpoint:
+    @pytest.mark.asyncio
+    async def test_sse_stream_connect_and_ping_directly(self, initialized_services: None):
+        if not ASGI_APP:
+            pytest.skip("ASGI app not found on MCP instance, skipping direct SSE test.")
+
+        async with httpx.AsyncClient(app=ASGI_APP, base_url="http://testserver") as client:
+            async with client.stream("GET", "/events") as response:
+                assert response.status_code == 200
+                assert response.headers["content-type"] == "text/event-stream"
+
+                events_received = 0
+                expected_events = 2 # Connect + 1 ping
+
+                stream_ended_prematurely = True
+                async for line in response.aiter_lines():
+                    # print(f"SSE Raw Line: {line}") # For debugging
+                    if line.startswith("event: connected"):
+                        events_received += 1
+                        # Next line should be data for connected
+                        data_line = await response.aiter_lines().__anext__()
+                        # print(f"SSE Connected Data: {data_line}") # For debugging
+                        assert data_line.startswith("data: ")
+                        payload = json.loads(data_line[len("data: "):])
+                        assert payload["message"] == "Successfully connected to SSE stream"
+
+                    elif line.startswith("event: ping"):
+                        events_received += 1
+                        # Next line should be data for ping
+                        data_line = await response.aiter_lines().__anext__()
+                        # print(f"SSE Ping Data: {data_line}") # For debugging
+                        assert data_line.startswith("data: ")
+                        payload = json.loads(data_line[len("data: "):])
+                        assert "heartbeat" in payload
+                        assert payload["message"] == "ping"
+
+                        # We've received enough events for the test
+                        if events_received >= expected_events:
+                            stream_ended_prematurely = False
+                            break
+
+                    # Handle empty lines between events
+                    elif not line.strip():
+                        continue
+
+                assert not stream_ended_prematurely, f"Stream ended before receiving {expected_events} events."
+                assert events_received >= expected_events
+
+    # TODO: Add a test for SSE that handles client disconnection if possible,
+    # but this is hard to simulate reliably with httpx without more control
+    # over the exact timing of request cancellation.
+
+if __name__ == "__main__":
+    # This allows running the tests directly with `python tests/test_new_endpoints.py`
+    # You might need to adjust for pytest specific features or run with `pytest tests/test_new_endpoints.py`
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Replaces the generic AI coding tool integration document with a dedicated section in the main README.md.

This new section, '💻 Editor & AI Tool Integration', provides specific instructions and JSON configuration examples for integrating the OpenEdu MCP server with the following AI coding tools:
- Cursor
- Windsurf
- Cline
- Roo Code
- Claude

The configurations use 'python -m src.main' as the server command and include placeholders for the project's root directory ('cwd').

Additionally:
- I removed the old 'docs/AI_CODING_TOOL_INTEGRATION.md' file.
- I removed the link to the old document from the 'Documentation' section in README.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new tool for processing standard input and returning formatted results.
	- Added a Server-Sent Events (SSE) endpoint for real-time event streaming.
- **Documentation**
	- Expanded README with detailed connectivity options, endpoint usage examples, and integration guides for various AI-assisted coding tools and IDEs.
- **Tests**
	- Added comprehensive tests covering the new standard input tool, HTTP endpoint, and SSE event streaming to ensure correct behavior and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->