### PR TITLE
Add cache health check and tests

### DIFF
--- a/src/services/cache_service.py
+++ b/src/services/cache_service.py
@@ -335,7 +335,24 @@ class CacheService:
                 
         except Exception as e:
             logger.error(f"Error cleaning up cache by size: {e}")
-    
+
+    async def health_check(self) -> bool:
+        """Verify that the cache database is reachable."""
+        if not self._initialized:
+            await self.initialize()
+
+        try:
+            async with aiosqlite.connect(self.db_path) as db:
+                await db.execute("SELECT 1")
+            return True
+        except Exception as e:
+            logger.error(f"Cache service health check failed: {e}")
+            raise CacheError(
+                "Cache health check failed",
+                "health_check",
+                str(e),
+            )
+
     async def close(self) -> None:
         """Close the cache service."""
         # Note: aiosqlite connections are closed automatically

--- a/src/services/cache_service.py
+++ b/src/services/cache_service.py
@@ -346,12 +346,12 @@ class CacheService:
                 await db.execute("SELECT 1")
             return True
         except Exception as e:
-            logger.error(f"Cache service health check failed: {e}")
+            logger.error("Cache service health check failed: %s", e)
             raise CacheError(
                 "Cache health check failed",
                 "health_check",
                 str(e),
-            )
+            ) from e
 
     async def close(self) -> None:
         """Close the cache service."""

--- a/src/tools/arxiv_tools.py
+++ b/src/tools/arxiv_tools.py
@@ -22,7 +22,7 @@ from config import Config
 from services.cache_service import CacheService
 from services.rate_limiting_service import RateLimitingService
 from services.usage_service import UsageService
-from exceptions import ToolError, ValidationError, APIError
+from exceptions import ToolError, ValidationError, APIError, CacheError
 
 logger = logging.getLogger(__name__)
 
@@ -837,7 +837,11 @@ class ArxivTool(BaseTool):
             api_health = await self.client.health_check()
             
             # Check cache service
-            cache_healthy = await self.cache_service.health_check()
+            try:
+                cache_healthy = await self.cache_service.health_check()
+            except CacheError as e:
+                logger.error(f"Cache health check failed: {e}")
+                cache_healthy = False
             
             # Check rate limiting
             rate_limit_status = await self.rate_limiting_service.get_rate_limit_status(self.api_name)

--- a/tests/test_services/test_cache_service.py
+++ b/tests/test_services/test_cache_service.py
@@ -1,0 +1,22 @@
+import pytest
+from unittest.mock import patch
+
+from config import CacheConfig
+from services.cache_service import CacheService
+from exceptions import CacheError
+
+
+@pytest.mark.asyncio
+async def test_health_check_success(tmp_path):
+    db_path = tmp_path / "cache.db"
+    service = CacheService(CacheConfig(database_path=str(db_path)))
+    assert await service.health_check() is True
+
+
+@pytest.mark.asyncio
+async def test_health_check_failure(tmp_path):
+    db_path = tmp_path / "cache.db"
+    service = CacheService(CacheConfig(database_path=str(db_path)))
+    with patch("aiosqlite.connect", side_effect=Exception("db error")):
+        with pytest.raises(CacheError):
+            await service.health_check()


### PR DESCRIPTION
## Summary
- implement SQLite health check in `CacheService`
- handle `CacheError` in `ArxivTool.health_check`
- add unit tests for cache service and cache failure scenario

## Testing
- `pytest -o addopts='' tests/test_services/test_cache_service.py tests/test_tools/test_arxiv_tools.py::TestArxivTool::test_health_check_cache_failure -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6dd02d748322bd932247e12c7381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a health check capability for the cache service to improve monitoring and reliability.
- **Bug Fixes**
  - Improved error handling during cache health checks to prevent failures from affecting other system components.
- **Tests**
  - Introduced new tests to verify cache health check success and failure scenarios.
  - Added tests to ensure proper handling of cache health check failures within related tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->